### PR TITLE
Add the ignorePath config for missed translations

### DIFF
--- a/src/actions/display.ts
+++ b/src/actions/display.ts
@@ -77,6 +77,7 @@ export const displayMissedTranslations = async (
     `${process.cwd()}/${config.srcPath}`,
     {
       srcExtensions: config.srcExtensions,
+      ignorePaths: config.ignorePaths,
     },
   );
 

--- a/src/helpers/files.ts
+++ b/src/helpers/files.ts
@@ -86,7 +86,7 @@ export const generateFilesPaths = async (
     if (
       ignorePaths &&
       ignorePaths.some((ignorePath) =>
-        path.dirname(v).endsWith(`/${ignorePath}`),
+        path.dirname(v).includes(`/${ignorePath}`),
       )
     ) {
       return false;


### PR DESCRIPTION
## Context

I added 2 things since the [Add ignorePaths option](https://github.com/mxmvshnvsk/i18n-unused/commit/f718feccbd78a4377ffb34a80ed8374a9fbdc79b) commit.

- The `ignorePaths` config for missed translations.
- The fact that the path is ignored if the path `includes` the `ignorePath` and not if it `endsWith` the `ignorePath`.

Because if you want to ignore `node_modules` this will likely not be the last folder. :)