### PR TITLE
Add the translationKeyMatcher config for unused translations

### DIFF
--- a/src/actions/display.ts
+++ b/src/actions/display.ts
@@ -35,6 +35,7 @@ export const displayUnusedTranslations = async (
       ignoreComments: config.ignoreComments,
       localeFileParser: config.localeFileParser,
       excludeTranslationKey: config.excludeKey,
+      translationKeyMatcher: config.translationKeyMatcher,
     },
   );
 

--- a/src/actions/mark.ts
+++ b/src/actions/mark.ts
@@ -39,6 +39,7 @@ export const markUnusedTranslations = async (
       ignoreComments: config.ignoreComments,
       localeFileParser: config.localeFileParser,
       excludeTranslationKey: config.excludeKey,
+      translationKeyMatcher: config.translationKeyMatcher,
     },
   );
 

--- a/src/actions/remove.ts
+++ b/src/actions/remove.ts
@@ -39,6 +39,7 @@ export const removeUnusedTranslations = async (
       ignoreComments: config.ignoreComments,
       localeFileParser: config.localeFileParser,
       excludeTranslationKey: config.excludeKey,
+      translationKeyMatcher: config.translationKeyMatcher,
     },
   );
 

--- a/src/core/translations.ts
+++ b/src/core/translations.ts
@@ -49,10 +49,11 @@ const removeComments = (fileTxt: string): string => {
 
 interface unusedOptions {
   context: boolean;
-  contextSeparator: string,
+  contextSeparator: string;
   ignoreComments: boolean;
   localeFileParser?: ModuleResolver;
   excludeTranslationKey?: string | string[];
+  translationKeyMatcher?: TranslationKeyMatcher;
 }
 
 export const collectUnusedTranslations = async (
@@ -64,6 +65,7 @@ export const collectUnusedTranslations = async (
     excludeTranslationKey,
     contextSeparator,
     context,
+    translationKeyMatcher,
   }: unusedOptions,
 ): Promise<UnusedTranslations> => {
   const translations: UnusedTranslation = [];
@@ -80,7 +82,11 @@ export const collectUnusedTranslations = async (
       const file = readFileSync(filePath).toString();
 
       [...translationsKeys].forEach((key: string) => {
-        if ((ignoreComments ? removeComments(file) : file).includes(key)) {
+        const matchKeys =
+          (ignoreComments ? removeComments(file) : file).match(
+            translationKeyMatcher,
+          ) || [];
+        if ([...new Set(matchKeys)].toString().includes(key)) {
           translationsKeys.splice(translationsKeys.indexOf(key), 1);
         }
       });
@@ -101,7 +107,7 @@ export const collectUnusedTranslations = async (
 
 interface missedOptions {
   context: boolean;
-  contextSeparator: string,
+  contextSeparator: string;
   ignoreComments: boolean;
   localeFileParser?: ModuleResolver;
   excludeTranslationKey?: string | string[];


### PR DESCRIPTION
When comparing with key string, I could not identify whether it was object literal or i18n compared to the message key.

- Example : `$t('city.name')` and `{{ city.name }}` 

So, add the `translationKeyMatcher` config for unused translations.