### PR TITLE
Add option for JSON indent value

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ module.exports = {
 | translationSeparator         | separator for translations using in code | no | string | '.'
 | translationContextSeparator  | separator for i18n context (see `context` option) | no | string | '_'
 | missedTranslationParser  | parser for ejecting value from `translationKeyMatcher` matches | no | RegExp, (v: string) => string | RegExp, match value inside rounded brackets
-| jsonFileIndentValue  | json indent value for writing json file, either a number of spaces, or a string to indent with. (i.e. `2`, `4`, `\t`) | no | string , number | `2`
+| localeJsonStringifyIndent  | json indent value for writing json file, either a number of spaces, or a string to indent with. (i.e. `2`, `4`, `\t`) | no | string , number | `2`
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ module.exports = {
 | translationSeparator         | separator for translations using in code | no | string | '.'
 | translationContextSeparator  | separator for i18n context (see `context` option) | no | string | '_'
 | missedTranslationParser  | parser for ejecting value from `translationKeyMatcher` matches | no | RegExp, (v: string) => string | RegExp, match value inside rounded brackets
+| jsonFileIndentValue  | json indent value for writing json file, either a number of spaces, or a string to indent with. (i.e. `2`, `4`, `\t`) | no | string , number | `2`
 
 ## Usage
 

--- a/src/actions/mark.ts
+++ b/src/actions/mark.ts
@@ -1,5 +1,3 @@
-import { writeFileSync } from 'fs';
-
 import { createRequire } from 'module';
 
 import { RunOptions, UnusedTranslations } from '../types';
@@ -12,6 +10,7 @@ import { checkUncommittedChanges } from '../helpers/git';
 import { importMetaUrl } from '../helpers/meta';
 
 import { GREEN } from '../helpers/consoleColor';
+import { writeJsonFile } from "../helpers/writeJsonFile";
 
 export const markUnusedTranslations = async (
   options: RunOptions,
@@ -67,7 +66,7 @@ export const markUnusedTranslations = async (
       ),
     );
 
-    writeFileSync(translation.localePath, JSON.stringify(locale, null, 2));
+    writeJsonFile(translation.localePath, locale, config);
 
     console.log(GREEN, `Successfully marked: ${translation.localePath}`);
   });

--- a/src/actions/remove.ts
+++ b/src/actions/remove.ts
@@ -1,5 +1,3 @@
-import { writeFileSync } from 'fs';
-
 import { createRequire } from 'module';
 
 import { RunOptions, UnusedTranslations } from '../types';
@@ -12,6 +10,7 @@ import { checkUncommittedChanges } from '../helpers/git';
 import { importMetaUrl } from '../helpers/meta';
 
 import { GREEN } from '../helpers/consoleColor';
+import { writeJsonFile } from "../helpers/writeJsonFile";
 
 export const removeUnusedTranslations = async (
   options: RunOptions,
@@ -67,7 +66,7 @@ export const removeUnusedTranslations = async (
       ),
     );
 
-    writeFileSync(translation.localePath, JSON.stringify(locale, null, 2));
+    writeJsonFile(translation.localePath, locale, config);
 
     console.log(GREEN, `Successfully removed: ${translation.localePath}`);
   });

--- a/src/actions/sync.ts
+++ b/src/actions/sync.ts
@@ -1,5 +1,3 @@
-import fs from 'fs';
-
 import { createRequire } from 'module';
 
 import { RunOptions, RecursiveStruct } from '../types';
@@ -10,6 +8,7 @@ import { checkUncommittedChanges } from '../helpers/git';
 import { importMetaUrl } from '../helpers/meta';
 
 import { GREEN } from '../helpers/consoleColor';
+import { writeJsonFile } from "../helpers/writeJsonFile";
 
 export const mergeLocaleData = (
   source: RecursiveStruct,
@@ -56,7 +55,7 @@ export const syncTranslations = async (
     checkUncommittedChanges();
   }
 
-  fs.writeFileSync(targetPath, JSON.stringify(mergedLocale, null, 2));
+  writeJsonFile(targetPath, mergedLocale, config);
 
   console.log(GREEN, 'Translations are synchronized');
 

--- a/src/core/initialize.ts
+++ b/src/core/initialize.ts
@@ -18,6 +18,7 @@ const defaultValues: RunOptions = {
   localeFileParser: (m: RecursiveStruct): RecursiveStruct =>
     (m.default || m) as RecursiveStruct,
   missedTranslationParser: /\(([^)]+)\)/,
+  jsonFileIndentValue: 2,
 };
 
 export const initialize = async (

--- a/src/core/initialize.ts
+++ b/src/core/initialize.ts
@@ -18,7 +18,7 @@ const defaultValues: RunOptions = {
   localeFileParser: (m: RecursiveStruct): RecursiveStruct =>
     (m.default || m) as RecursiveStruct,
   missedTranslationParser: /\(([^)]+)\)/,
-  jsonFileIndentValue: 2,
+  localeJsonStringifyIndent: 2,
 };
 
 export const initialize = async (

--- a/src/helpers/writeJsonFile.ts
+++ b/src/helpers/writeJsonFile.ts
@@ -1,0 +1,16 @@
+import { writeFileSync } from "fs";
+import { RecursiveStruct } from "../types";
+
+interface writeJsonFileOptions {
+  jsonFileIndentValue?: string | number;
+}
+
+export const writeJsonFile = (
+  filePath: string,
+  data: RecursiveStruct,
+  config: writeJsonFileOptions
+): void => {
+  const jsonString = JSON.stringify(data, null, config.jsonFileIndentValue);
+  const jsonStringWithNewLine = `${jsonString}\n`;
+  writeFileSync(filePath, jsonStringWithNewLine);
+};

--- a/src/helpers/writeJsonFile.ts
+++ b/src/helpers/writeJsonFile.ts
@@ -2,7 +2,7 @@ import { writeFileSync } from "fs";
 import { RecursiveStruct } from "../types";
 
 interface writeJsonFileOptions {
-  jsonFileIndentValue?: string | number;
+  localeJsonStringifyIndent?: string | number;
 }
 
 export const writeJsonFile = (
@@ -10,7 +10,7 @@ export const writeJsonFile = (
   data: RecursiveStruct,
   config: writeJsonFileOptions
 ): void => {
-  const jsonString = JSON.stringify(data, null, config.jsonFileIndentValue);
+  const jsonString = JSON.stringify(data, null, config.localeJsonStringifyIndent);
   const jsonStringWithNewLine = `${jsonString}\n`;
   writeFileSync(filePath, jsonStringWithNewLine);
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -58,4 +58,5 @@ export interface RunOptions {
   translationSeparator?: string;
   translationContextSeparator?: string;
   missedTranslationParser?: MissedTranslationParser;
+  jsonFileIndentValue: string | number;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -58,5 +58,5 @@ export interface RunOptions {
   translationSeparator?: string;
   translationContextSeparator?: string;
   missedTranslationParser?: MissedTranslationParser;
-  jsonFileIndentValue: string | number;
+  localeJsonStringifyIndent: string | number;
 }

--- a/tests/helpers/writeJsonFile.spec.ts
+++ b/tests/helpers/writeJsonFile.spec.ts
@@ -16,7 +16,7 @@ describe('writeJsonFile', () => {
         test: 'value',
       };
       const config: RunOptions = {
-        jsonFileIndentValue: 2,
+        localeJsonStringifyIndent: 2,
       }
 
       writeJsonFile(filePath, jsonData, config);
@@ -27,14 +27,14 @@ describe('writeJsonFile', () => {
     });
   });
 
-  describe('jsonFileIndentValue of 4', () => {
+  describe('localeJsonStringifyIndent of 4', () => {
     it('should indent with 4 spaces', async () => {
       const filePath = '/test-file.json';
       const jsonData = {
         test: 'value',
       };
       const config: RunOptions = {
-        jsonFileIndentValue: 4,
+        localeJsonStringifyIndent: 4,
       }
 
       writeJsonFile(filePath, jsonData, config);
@@ -45,14 +45,14 @@ describe('writeJsonFile', () => {
     });
   });
 
-  describe('jsonFileIndentValue of \t', () => {
+  describe('localeJsonStringifyIndent of \t', () => {
     it('should indent with 1 tab', async () => {
       const filePath = '/test-file.json';
       const jsonData = {
         test: 'value',
       };
       const config: RunOptions = {
-        jsonFileIndentValue: '\t',
+        localeJsonStringifyIndent: '\t',
       }
 
       writeJsonFile(filePath, jsonData, config);
@@ -64,14 +64,14 @@ describe('writeJsonFile', () => {
   });
 
 
-  describe('jsonFileIndentValue of `indent`', () => {
+  describe('localeJsonStringifyIndent of `indent`', () => {
     it('should indent with the string `indent`', async () => {
       const filePath = '/test-file.json';
       const jsonData = {
         test: 'value',
       };
       const config: RunOptions = {
-        jsonFileIndentValue: 'indent',
+        localeJsonStringifyIndent: 'indent',
       }
 
       writeJsonFile(filePath, jsonData, config);

--- a/tests/helpers/writeJsonFile.spec.ts
+++ b/tests/helpers/writeJsonFile.spec.ts
@@ -1,0 +1,84 @@
+import { jest } from '@jest/globals';
+import { writeFileSync } from 'fs';
+import {RunOptions} from "../../src/types";
+import {writeJsonFile} from "../../src/helpers/writeJsonFile";
+
+
+jest.mock("fs", () => ({
+  writeFileSync: jest.fn()
+}));
+
+describe('writeJsonFile', () => {
+  describe('defaultValue', () => {
+    it('should indent with 2 spaces', async () => {
+      const filePath = '/test-file.json';
+      const jsonData = {
+        test: 'value',
+      };
+      const config: RunOptions = {
+        jsonFileIndentValue: 2,
+      }
+
+      writeJsonFile(filePath, jsonData, config);
+
+      const expectedValue = `{\n  "test": "value"\n}\n`;
+
+      expect(writeFileSync).toHaveBeenCalledWith(filePath, expectedValue);
+    });
+  });
+
+  describe('jsonFileIndentValue of 4', () => {
+    it('should indent with 4 spaces', async () => {
+      const filePath = '/test-file.json';
+      const jsonData = {
+        test: 'value',
+      };
+      const config: RunOptions = {
+        jsonFileIndentValue: 4,
+      }
+
+      writeJsonFile(filePath, jsonData, config);
+
+      const expectedValue = `{\n    "test": "value"\n}\n`;
+
+      expect(writeFileSync).toHaveBeenCalledWith(filePath, expectedValue);
+    });
+  });
+
+  describe('jsonFileIndentValue of \t', () => {
+    it('should indent with 1 tab', async () => {
+      const filePath = '/test-file.json';
+      const jsonData = {
+        test: 'value',
+      };
+      const config: RunOptions = {
+        jsonFileIndentValue: '\t',
+      }
+
+      writeJsonFile(filePath, jsonData, config);
+
+      const expectedValue = `{\n\t"test": "value"\n}\n`;
+
+      expect(writeFileSync).toHaveBeenCalledWith(filePath, expectedValue);
+    });
+  });
+
+
+  describe('jsonFileIndentValue of `indent`', () => {
+    it('should indent with the string `indent`', async () => {
+      const filePath = '/test-file.json';
+      const jsonData = {
+        test: 'value',
+      };
+      const config: RunOptions = {
+        jsonFileIndentValue: 'indent',
+      }
+
+      writeJsonFile(filePath, jsonData, config);
+
+      const expectedValue = `{\nindent"test": "value"\n}\n`;
+
+      expect(writeFileSync).toHaveBeenCalledWith(filePath, expectedValue);
+    });
+  });
+});


### PR DESCRIPTION
This creates a new RunOption for `jsonFileIndentValue`. This allows controlling how the output json is generated. The current default was `2` and that is preserved in this new option, but now allows overriding with `4` or even `'\t'` to get tabs.

I added a helper function to wrap the json file writing, then added a test suite to validate the output.

Let me know if you think this should change at all, I am not too sure about the option name.