### PR TITLE
ESM support + Easier way to specify translationKeyMatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ module.exports = {
   srcPath: 'src',
 };
 ```
+For ES-Modules (esm) use `i18n-unused.config.cjs`. You can also use the `.json` with no support for callbacks.
+
 ### Configuration options
 
 | Option name | <div style="width: 280px">Description</div> | Required | Type | <div style="min-width: 100px">Default value</div> |
@@ -62,6 +64,12 @@ Display unused translations:
 ```bash
 i18n-unused display-unused
 ```
+
+Display unused translations for [mashpie/i18n-node](https://github.com/mashpie/i18n-node):
+```bash
+i18n-unused display-unused --translation-key-matcher '/(?:[$ .](__))\(.*?\)/gi'
+```
+
 
 Mark unused translations via `[UNUSED]` or marker from config (works only with `json` for now):
 ```bash

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ module.exports = {
 | srcPath               | path to search for translations | no | string | `''` (same as run folder)
 | srcExtensions         | allowed file extensions for translations | no | string[] | ['js', 'ts', 'jsx', 'tsx', 'vue']
 | ignorePaths           | ignored paths, eg: `['src/ignored-folder']`, should start similarly `srcPath` | no | string[] | -
-| translationKeyMatcher | matcher to searching for translation keys in files | no | RegExp | RegExp, match `$_`, `$t`, `t`, `$tc`, `tc` and `i18nKey`
+| translationKeyMatcher | matcher to search for translation keys in files | no | RegExp | RegExp, match `$_`, `$t`, `t`, `$tc`, `tc` and `i18nKey`
 | excludeKey            | doesn't process translations that include passed key(s), for example if you set `excludeKey: '.props.'`, script will ignore `Button.props.value`. | no | string, string[] | -
 | ignoreComments        | Ignore code comments in src files. | no | boolean | false
 | marker                | special string to mark unused translations, it'll added via `mark-unused` | no | string | '[UNUSED]'

--- a/bin/i18n-unused.cjs
+++ b/bin/i18n-unused.cjs
@@ -11,6 +11,16 @@ const {
   syncTranslations,
 } = require('../dist/i18n-unused.cjs');
 
+/**
+ * Transform the escaped string provided into a valid regex
+ * @param {string} str
+ * @return {RegExp}
+ */
+const parseRegex = (str) => {
+  const parts = str.split("/");
+  return new RegExp(`${parts[1]}`.replace(/\\\\/g, "\\"), parts[2]);
+}
+
 program.description(description);
 
 program.version(version, '-v --version', 'output version');
@@ -18,6 +28,7 @@ program.version(version, '-v --version', 'output version');
 program
   .option('-sExt, --src-extensions [srcExtensions...]', 'files extensions, which includes for searching (ext ext ext; by default: js, ts, jsx, tsx, vue)')
   .option('-lExt, --locales-extensions [localesExtensions...]', 'locales files extensions (ext,ext,ext; by default: json)')
+  .option('-lExt, --translation-key-matcher <translationKeyMatcher>', '{string} locales matcher to search for translation keys in files by default: \'/(?:[$ .](_|t|tc|i18nKey))\\(.*?\\)/gi\'', parseRegex)
   .option('-sPath, --src-path <srcPath>', 'path to source of code (path, ex. \'src\')')
   .option('-lPath, --locales-path <localesPath>', 'path to locales (path, ex. \'src/locales\')');
 

--- a/bin/i18n-unused.cjs
+++ b/bin/i18n-unused.cjs
@@ -9,17 +9,10 @@ const {
   removeUnusedTranslations,
   markUnusedTranslations,
   syncTranslations,
+  parseRegex
 } = require('../dist/i18n-unused.cjs');
 
-/**
- * Transform the escaped string provided into a valid regex
- * @param {string} str
- * @return {RegExp}
- */
-const parseRegex = (str) => {
-  const parts = str.split("/");
-  return new RegExp(`${parts[1]}`.replace(/\\\\/g, "\\"), parts[2]);
-}
+
 
 program.description(description);
 

--- a/src/core/initialize.ts
+++ b/src/core/initialize.ts
@@ -3,6 +3,8 @@
 import { resolveFile } from '../helpers/files';
 
 import { RunOptions, RecursiveStruct } from '../types';
+import fs                              from "fs";
+import {parseRegex}                    from "../helpers/parseRegex";
 
 const defaultValues: RunOptions = {
   srcPath: '',
@@ -27,12 +29,31 @@ export const initialize = async (
   let config: RunOptions = { ...inlineOptions };
 
   try {
-    const configFile = await resolveFile(
-      `${process.cwd()}/i18n-unused.config.js`,
-    );
+    const base = process.cwd();
 
-    config = { ...configFile, ...inlineOptions };
-  } catch (e) {}
+    let configFile: Partial<RunOptions> = {};
+
+    for (const ext of ["js", "cjs", "json"]) {
+      const path = `${base}/i18n-unused.config.${ext}`;
+      if (fs.existsSync(path)) {
+        configFile = await resolveFile(path);
+        // ⛔ There is no safe/reliable way to parse a function
+        // ✔ When the file is a JSON need to parse the regex
+        if (ext === "json") {
+          const potentialRegex = ["translationKeyMatcher", "missedTranslationParser", "localeNameResolver"];
+          potentialRegex.forEach(value => {
+            if (Object.prototype.hasOwnProperty.call(configFile, value)) {
+              configFile[value] = parseRegex(configFile[value]);
+            }
+          });
+        }
+        break;
+      }
+    }
+
+    config = {...configFile, ...inlineOptions};
+  } catch (e) {
+  }
 
   if (!config.localesPath) {
     throw new Error('Locales path is required');

--- a/src/helpers/files.ts
+++ b/src/helpers/files.ts
@@ -35,7 +35,7 @@ export const resolveFile = async (
     m = loader(filePath);
   } else if (ext === 'ts') {
     m = await tsImport.compile(filePath);
-  } else if (ext === 'js') {
+  } else if (["js", "cjs"].includes(ext)) {
     let r = createRequire(importMetaUrl());
     r = r('esm')(m /*, options*/);
     m = r(filePath);

--- a/src/helpers/parseRegex.ts
+++ b/src/helpers/parseRegex.ts
@@ -1,0 +1,9 @@
+/**
+ * Transform the escaped string provided into a valid regex
+ * @param {string} str
+ * @return {RegExp}
+ */
+export  const parseRegex = (str) => {
+  const parts = str.split("/");
+  return new RegExp(`${parts[1]}`.replace(/\\\\/g, "\\"), parts[2]);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,4 @@ export { syncTranslations } from './actions/sync';
 
 export { collectUnusedTranslations } from './core/translations';
 export { generateFilesPaths } from './helpers/files';
+export { parseRegex } from './helpers/parseRegex';


### PR DESCRIPTION
### New command --translation-key-matcher
This makes it easier to modify the matcher for more libraries like [i18n-node]( https://github.com/mashpie/i18n-node), who use `__` :
![display](https://user-images.githubusercontent.com/2999487/204080855-7da530d2-10f5-4dc0-ac7f-d4d63b4ea5f8.png)

![image](https://user-images.githubusercontent.com/2999487/204081014-99f7d66c-2574-4204-81f4-05de166a39b2.png)

### ESM module configuration file

When creating the configuration file from inside an ES-Modules (esm)  the parser is not able to read the Common-js module without the `.cjs` extension.

To fix that we could use a **.json** configuration file without the support for callbacks or a **.cjs** file.

 i18n-unused.config.json : 
```json
{
  "localesPath": "src/locales",
  "srcPath": "src",
  "translationKeyMatcher": "/(?:[$ .](_|t|tc|i18nKey|__))\\(.*?\\)/gi"
}
```

i18n-unused.config.cjs :
```javascript
module.exports = {
  localesPath: 'src/locales',
  srcPath: 'src',
  translationKeyMatcher: /(?:[$ .](_|t|tc|i18nKey|__))\(.*?\)/gi
};

```

closes #30
