### PR TITLE
Feat/add context matcher and export types

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ yarn add --dev i18n-unused
 Add config `i18n-unused.config.js` to your root folder:
 
 ```javascript
+/** @type {import('i18n-unused').RunOptions} */
 module.exports = {
   localesPath: 'src/locales',
   srcPath: 'src',
@@ -51,6 +52,7 @@ For ES-Modules (esm) use `i18n-unused.config.cjs`. You can also use the `.json` 
 | flatTranslations      | use flat translations, (eg: [Flat JSON](https://www.codeandweb.com/babeledit/documentation/file-formats#flat-json)) | no | boolean | false
 | translationSeparator         | separator for translations using in code | no | string | '.'
 | translationContextSeparator  | separator for i18n context (see `context` option) | no | string | '_'
+| translationContextMatcher | matcher to search for context endings | no | RegExp | RegExp, match `zero`, `one`, `two`, `few`, `many`, `other`, `male`, `female`, `0`, `1`, `2`, `3`, `4`, `5`, `plural`, `11` and `100`
 | missedTranslationParser  | parser for ejecting value from `translationKeyMatcher` matches | no | RegExp, (v: string) => string | RegExp, match value inside rounded brackets
 | localeJsonStringifyIndent  | json indent value for writing json file, either a number of spaces, or a string to indent with. (i.e. `2`, `4`, `\t`) | no | string , number | `2`
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "bin": "bin/i18n-unused.cjs",
   "main": "dist/i18n-unused.cjs",
   "module": "dist/i18n-unused.js",
+  "types": "dist/index.d.ts",
   "exports": {
     "require": "./dist/i18n-unused.cjs",
     "import": "./dist/i18n-unused.js"

--- a/src/actions/display.ts
+++ b/src/actions/display.ts
@@ -32,6 +32,7 @@ export const displayUnusedTranslations = async (
     {
       context: config.context,
       contextSeparator: config.translationContextSeparator,
+      contextMatcher: config.translationContextMatcher,
       ignoreComments: config.ignoreComments,
       localeFileParser: config.localeFileParser,
       localeFileLoader: config.localeFileLoader,
@@ -93,6 +94,7 @@ export const displayMissedTranslations = async (
     {
       context: config.context,
       contextSeparator: config.translationContextSeparator,
+      contextMatcher: config.translationContextMatcher,
       ignoreComments: config.ignoreComments,
       localeFileParser: config.localeFileParser,
       localeFileLoader: config.localeFileLoader,

--- a/src/actions/mark.ts
+++ b/src/actions/mark.ts
@@ -36,6 +36,7 @@ export const markUnusedTranslations = async (
     {
       context: config.context,
       contextSeparator: config.translationContextSeparator,
+      contextMatcher: config.translationContextMatcher,
       ignoreComments: config.ignoreComments,
       localeFileParser: config.localeFileParser,
       localeFileLoader: config.localeFileLoader,

--- a/src/actions/remove.ts
+++ b/src/actions/remove.ts
@@ -36,6 +36,7 @@ export const removeUnusedTranslations = async (
     {
       context: config.context,
       contextSeparator: config.translationContextSeparator,
+      contextMatcher: config.translationContextMatcher,
       ignoreComments: config.ignoreComments,
       localeFileParser: config.localeFileParser,
       localeFileLoader: config.localeFileLoader,

--- a/src/core/initialize.ts
+++ b/src/core/initialize.ts
@@ -15,6 +15,9 @@ const defaultValues: RunOptions = {
   flatTranslations: false,
   translationSeparator: ".",
   translationContextSeparator: "_",
+  // Based on https://www.i18next.com/misc/json-format
+  translationContextMatcher:
+    /^(zero|one|two|few|many|other|male|female|0|1|2|3|4|5|plural|11|100)$/,
   srcExtensions: ["js", "ts", "jsx", "tsx", "vue"],
   translationKeyMatcher: /(?:[$ .](_|t|tc|i18nKey))\(.*?\)/gi,
   localeFileParser: (m: RecursiveStruct): RecursiveStruct =>
@@ -41,6 +44,7 @@ export const initialize = async (
         // ✔ When the file is a JSON need to parse the regex
         if (ext === "json") {
           const potentialRegex = [
+            "translationContextMatcher",
             "translationKeyMatcher",
             "missedTranslationParser",
             "localeNameResolver",

--- a/src/core/translations.ts
+++ b/src/core/translations.ts
@@ -104,8 +104,10 @@ export const collectUnusedTranslations = async (
       if (customChecker) {
         customChecker(matchKeysSet, translationsKeys);
       } else {
-        [...translationsKeys].forEach((key: string) => {
-          if ([...matchKeysSet].toString().includes(key)) {
+        const matchKeysSetArrStr = [...matchKeysSet].toString();
+
+        [...translationsKeys].forEach((key) => {
+          if (matchKeysSetArrStr.includes(key)) {
             translationsKeys.splice(translationsKeys.indexOf(key), 1);
           }
         });

--- a/src/core/translations.ts
+++ b/src/core/translations.ts
@@ -53,6 +53,7 @@ const removeComments = (fileTxt: string): string => {
 interface unusedOptions {
   context: boolean;
   contextSeparator: string;
+  contextMatcher: RegExp;
   ignoreComments: boolean;
   localeFileParser?: ModuleResolver;
   localeFileLoader?: CustomFileLoader;
@@ -70,6 +71,7 @@ export const collectUnusedTranslations = async (
     localeFileLoader,
     customChecker,
     excludeTranslationKey,
+    contextMatcher,
     contextSeparator,
     context,
     translationKeyMatcher,
@@ -85,6 +87,7 @@ export const collectUnusedTranslations = async (
     );
     const translationsKeys = generateTranslationsFlatKeys(locale, {
       excludeKey: excludeTranslationKey,
+      contextMatcher,
       contextSeparator,
       context,
     });
@@ -125,6 +128,7 @@ export const collectUnusedTranslations = async (
 interface missedOptions {
   context: boolean;
   contextSeparator: string;
+  contextMatcher: RegExp;
   ignoreComments: boolean;
   localeFileParser?: ModuleResolver;
   localeFileLoader?: CustomFileLoader;
@@ -145,6 +149,7 @@ export const collectMissedTranslations = async (
     excludeTranslationKey,
     translationKeyMatcher,
     missedTranslationParser,
+    contextMatcher,
   }: missedOptions,
 ): Promise<MissedTranslations> => {
   const translations: MissedTranslation = [];
@@ -160,6 +165,7 @@ export const collectMissedTranslations = async (
         );
         const translationsKeys = generateTranslationsFlatKeys(locale, {
           excludeKey: excludeTranslationKey,
+          contextMatcher,
           contextSeparator,
           context,
         });

--- a/src/helpers/flatKeys.ts
+++ b/src/helpers/flatKeys.ts
@@ -35,19 +35,22 @@ export const generateTranslationsFlatKeys = (
     } else {
       keys.push(
         context
-          ? getKeyWithoutContext(key, contextSeparator, contextMatcher)
+          ? getKeyWithoutContext(flatKey, contextSeparator, contextMatcher)
           : flatKey,
       );
     }
   });
 
-  return excludeKey
+  const resultKeys = excludeKey
     ? keys.filter((k: string) =>
         typeof excludeKey === "string"
           ? !k.includes(excludeKey)
           : excludeKey.every((ek) => !k.includes(ek)),
       )
     : keys;
+
+  // The context removal can cause duplicates, so we need to remove them
+  return [...new Set(resultKeys)];
 };
 
 /**
@@ -56,15 +59,19 @@ export const generateTranslationsFlatKeys = (
  * Makes sure translation keys like `some_key_i_have` is not treated as context.
  */
 const getKeyWithoutContext = (
-  key: string,
+  flatKey: string,
   contextSeparator: string,
   contextMatcher: RegExp,
 ) => {
-  const splitted = key.split(contextSeparator);
-  if (splitted.length === 1) return key;
+  const splitted = flatKey.split(contextSeparator);
+  if (splitted.length === 1) return flatKey;
+
   const lastPart = splitted[splitted.length - 1];
+
+  // If the last part is a context, remove it
   if (lastPart.match(contextMatcher)) {
-    return splitted.slice(0, splitted.length - 1).join(contextSeparator);
+    return splitted.slice(0, splitted.length - 2).join(contextSeparator);
   }
+  // Otherwise, join all parts
   return splitted.join(contextSeparator);
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,5 @@ export { syncTranslations } from "./actions/sync";
 export { collectUnusedTranslations } from "./core/translations";
 export { generateFilesPaths } from "./helpers/files";
 export { parseRegex } from "./helpers/parseRegex";
+
+export { RunOptions } from "./types";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -45,25 +45,106 @@ export type CustomChecker = (
 ) => void;
 
 export interface RunOptions {
-  localesExtensions?: string[];
+  /**
+   * Path to the locales folder
+   */
   localesPath?: string;
-  srcExtensions?: string[];
-  srcPath?: string;
-  ignorePaths?: string[];
-  excludeKey?: string | string[];
-  marker?: string;
-  gitCheck?: boolean;
-  ignoreComments?: boolean;
-  translationKeyMatcher?: TranslationKeyMatcher;
+  /**
+   * Allowed file extensions for locales
+   * @default ['json'] if `localeNameResolver` is not set
+   */
+  localesExtensions?: string[];
+  /**
+   * File name resolver for locales
+   */
   localeNameResolver?: ModuleNameResolver;
-  localeFileParser?: ModuleResolver;
-  localeFileLoader?: CustomFileLoader;
+  /**
+   * Function to check if a key is used, if so the key should be removed from
+   * translationsKeys
+   */
   customChecker?: CustomChecker;
+  /**
+   * Resolve locale imports, for example if you use named imports from locales
+   * files, just wrap it to your own resolver
+   * @default (m) => m.default
+   */
+  localeFileParser?: ModuleResolver;
+  /**
+   * Load the locale file manually (e.g. for using your own parser)
+   */
+  localeFileLoader?: CustomFileLoader;
+  /**
+   * Path to search for translations
+   * @default process.cwd()
+   */
+  srcPath?: string;
+  /**
+   * Allowed file extensions for translations
+   * @default ['js', 'jsx', 'ts', 'tsx', 'vue']
+   */
+  srcExtensions?: string[];
+  /**
+   * Ignore paths, eg: `['src/ignored-folder']`, should start similarly srcPath
+   */
+  ignorePaths?: string[];
+  /**
+   * Matcher to search for translation keys in files
+   * @default RegExp, match $_, $t, t, $tc, tc and i18nKey
+   */
+  translationKeyMatcher?: TranslationKeyMatcher;
+  /**
+   * Doesn't process translations that include passed key(s), for example if you
+   * set `excludeKey: '.props.'`, script will ignore `Button.props.value`.
+   */
+  excludeKey?: string | string[];
+  /**
+   * Ignore code comments in src files.
+   * @default false
+   */
+  ignoreComments?: boolean;
+  /**
+   * Special string to mark unused translations, it'll added via mark-unused
+   * @default '[UNUSED]'
+   */
+  marker?: string;
+  /**
+   * Show git state change tree
+   * @default false
+   */
+  gitCheck?: boolean;
+  /**
+   * Use i18n context, (eg: {@link https://www.i18next.com/translation-function/plurals Plurals})
+   * @default true
+   */
   context?: boolean;
+  /**
+   * Use flat translations, (eg: {@link https://www.codeandweb.com/babeledit/documentation/file-formats#flat-json Flat JSON})
+   */
   flatTranslations?: boolean;
+  /**
+   * Separator for translations using in code
+   * @default '.'
+   */
   translationSeparator?: string;
+  /**
+   * Separator for i18n (see {@link context context option})
+   * @default '_'
+   */
   translationContextSeparator?: string;
+  /**
+   * Matcher to search for i18n context in translations
+   * @default RegExp, match `zero`, `one`, `two`, `few`, `many`, `other`, `male`, `female`, `0`, `1`, `2`, `3`, `4`, `5`, `plural`, `11` and `100`
+   */
   translationContextMatcher?: RegExp;
+  /**
+   * Parser for ejecting value from {@link translationKeyMatcher} matches
+   * @default RegExp, match value inside rounded brackets
+   */
   missedTranslationParser?: MissedTranslationParser;
+  /**
+   * Json indent value for writing json file, either a number of spaces, or a
+   * string to indent with. (i.e. `2`, `4`, `\t`)
+   * @default 2
+   */
   localeJsonStringifyIndent: string | number;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -63,6 +63,7 @@ export interface RunOptions {
   flatTranslations?: boolean;
   translationSeparator?: string;
   translationContextSeparator?: string;
+  translationContextMatcher?: RegExp;
   missedTranslationParser?: MissedTranslationParser;
   localeJsonStringifyIndent: string | number;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,9 +14,8 @@
     "baseUrl": ".",
     "outDir": "dist",
     "paths": {
-      "*": [
-        "node_modules/*"
-      ]
+      "*": ["node_modules/*"]
     }
   },
+  "include": ["src"]
 }


### PR DESCRIPTION
Hi, this PR adds a new option `translationContextMatcher`.

It's purpose is to not split every key up by the `contextSeperator`, but only remove context suffixes. 

In my code base it made the result of the CLI unusable since the keys are snaked case.

Example:

```json
{
   "press_to_deselect": "..."
}
```
The `translationContextMatcher` defaults to a regex that should capture the context used by i18n-next in the various versions of their JSON Format. I wasn't sure if anything else existed out there, so I made it configurable.

Besides that I've moved some of the documentation from the README into the `RunOptions` interface and exported it, allowing users to have autocomplete when creating their config.

I also moved this part `[...matchKeysSet].toString()` out of the for loop, since it seemed unnecessary to compute the string every iteration.

Let me know if you have any comments.