### PR TITLE
feat: extend default key matcher

### DIFF
--- a/src/core/initialize.ts
+++ b/src/core/initialize.ts
@@ -19,7 +19,7 @@ const defaultValues: RunOptions = {
   translationContextMatcher:
     /^(zero|one|two|few|many|other|male|female|0|1|2|3|4|5|plural|11|100)$/,
   srcExtensions: ["js", "ts", "jsx", "tsx", "vue"],
-  translationKeyMatcher: /(?:[$ .](_|t|tc|i18nKey))\(.*?\)/gi,
+  translationKeyMatcher: /(?:[$ .](_|t|tc|i18nKey))\(([\n\r\s]|.)*?\)/gi,
   localeFileParser: (m: RecursiveStruct): RecursiveStruct =>
     (m.default || m) as RecursiveStruct,
   missedTranslationParser: /\(([^)]+)\)/,


### PR DESCRIPTION
Closes https://github.com/mxmvshnvsk/i18n-unused/issues/36

---

**This PR extends** the default `translationKeyMatcher` to match uses of translations which spread over multiple lines.
E.g.:
```js
this.$t(
  'app.user.confirmation.delete',
  { user: 'MyUser' },
);

this.$t(
  'app.user.confirmation.hello',
);
``` 

---

**Without the changes** of the PR the above uses of `t` are not and only "one line" uses are recognized.
E.g.:
```js
this.$t('app.user.confirmation.delete', { user: 'MyUser' });

this.$t('app.user.confirmation.hello');
```