### PR TITLE
Fix for matching strings like `{t("some.key")}`

### DIFF
--- a/src/core/initialize.ts
+++ b/src/core/initialize.ts
@@ -19,7 +19,7 @@ const defaultValues: RunOptions = {
   translationContextMatcher:
     /^(zero|one|two|few|many|other|male|female|0|1|2|3|4|5|plural|11|100)$/,
   srcExtensions: ["js", "ts", "jsx", "tsx", "vue"],
-  translationKeyMatcher: /(?:[$ .](_|t|tc|i18nKey))\(([\n\r\s]|.)*?\)/gi,
+  translationKeyMatcher: /(?:[.$\s]*\{?)?(_|t|tc|i18nKey))\(([\n\r\s]|.)*?\)/gi,
   localeFileParser: (m: RecursiveStruct): RecursiveStruct =>
     (m.default || m) as RecursiveStruct,
   missedTranslationParser: /\(([^)]+)\)/,


### PR DESCRIPTION
This PR fixes an issue where strings like `{t("some.key")}` were not being matched due to the `{` symbol. 

The `{t(...)}` pattern is suggested in the official i18next documentation, so it’s a common use case that many developers will encounter. For example, it’s used in the official [react-i18next example](https://github.com/i18next/react-i18next/blob/master/example/react-typescript/simple/src/App.tsx#L12).
