### PR TITLE
feat: Add error handling for unused  and missed translations

### DIFF
--- a/src/actions/display.ts
+++ b/src/actions/display.ts
@@ -66,6 +66,14 @@ export const displayUnusedTranslations = async (
     )}kb`,
   );
 
+  if (config.throwErrorOnUnused) {
+    throw new Error(
+      `Unused translations found in ${unusedTranslations.translations.map(
+        ({ localePath }) => localePath,
+      )}`,
+    );
+  }
+
   return unusedTranslations;
 };
 
@@ -137,6 +145,14 @@ export const displayMissedTranslations = async (
   console.log(
     `Total missed dynamic translations count: ${missedTranslations.totalDynamicCount}`,
   );
+
+  if (config.throwErrorOnMissed) {
+    throw new Error(
+      `Missed translations found in ${missedTranslations.translations.map(
+        ({ filePath }) => filePath,
+      )}`,
+    );
+  }
 
   return missedTranslations;
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -149,13 +149,13 @@ export interface RunOptions {
   localeJsonStringifyIndent: string | number;
 
   /**
-   * Occur error when found unused translations
+   * Throw error when found unused translations
    * @default false
    */
   throwErrorOnUnused?: boolean;
 
   /**
-   * Occur error when found missed translations
+   * Throw error when found missed translations
    * @default false
    */
   throwErrorOnMissed?: boolean;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -147,4 +147,16 @@ export interface RunOptions {
    * @default 2
    */
   localeJsonStringifyIndent: string | number;
+
+  /**
+   * Occur error when found unused translations
+   * @default false
+   */
+  throwErrorOnUnused?: boolean;
+
+  /**
+   * Occur error when found missed translations
+   * @default false
+   */
+  throwErrorOnMissed?: boolean;
 }


### PR DESCRIPTION
Closes #52 

This PR modifies the behavior so that when the displayUnusedTranslations or displayMissedTranslations commands are executed, an error is thrown if any unused or missed keys are found, respectively. This allows, for example, a GitHub Action running displayUnusedTranslations to fail if unused keys are detected.